### PR TITLE
ci(register): do no use moniker in created branch name

### DIFF
--- a/.github/workflows/register-validator.yml
+++ b/.github/workflows/register-validator.yml
@@ -151,7 +151,7 @@ jobs:
           committer: ${{ secrets.OKP4_BOT_GIT_COMMITTER_NAME }} <${{ secrets.OKP4_BOT_GIT_COMMITTER_EMAIL }}>
           author: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }} <${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}>
           token: ${{ secrets.OKP4_TOKEN }}
-          branch: feat/register-${{ needs.resolve-context.outputs.moniker }}-${{ needs.resolve-context.outputs.network }}
+          branch: feat/${{ github.event.issue.number }}-register-${{ needs.resolve-context.outputs.network }}
           title: '⚖️ Register `${{ needs.resolve-context.outputs.moniker }}` Validator'
           body: |
             Register [new validator](${{ github.event.issue.html_url }}) gentx on the ${{ needs.resolve-context.outputs.network }} network.


### PR DESCRIPTION
Following https://github.com/okp4/networks/pull/20, use also the github issue number in the created branch name instead of the moniker, for the same format issues.