### PR TITLE
Ci/limit commit message length

### DIFF
--- a/.github/workflows/register-validator.yml
+++ b/.github/workflows/register-validator.yml
@@ -24,10 +24,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
-      - name: Setup jq
-        run: |
-          sudo apt install -y jq
-
       - name: Parse issue form content
         id: parse-issue
         uses: stefanbuck/github-issue-parser@v2

--- a/.github/workflows/register-validator.yml
+++ b/.github/workflows/register-validator.yml
@@ -136,14 +136,30 @@ jobs:
           docker run --rm -v $NODE_HOME:$NODE_HOME -v $PWD/chains/${{ needs.resolve-context.outputs.network }}/gentx:/gentx okp4/okp4d:`cat ./chains/${{ needs.resolve-context.outputs.network }}/version.txt` collect-gentxs --home $NODE_HOME --gentx-dir /gentx
           cp $NODE_HOME/config/genesis.json chains/${{ needs.resolve-context.outputs.network }}/genesis.json
 
+      - name: Prepare commit message
+        id: commit-message
+        run: |
+          type=feat
+          scope="${{ needs.resolve-context.outputs.network }}"
+          description="register validator gentx ${{ needs.resolve-context.outputs.moniker }}"
+          body="Closes #${{ github.event.issue.number }}"
+
+          line1="$type($scope): $description"
+          line1=$(echo "$line1" | awk -v len=90 '{ if (length($0) > len) print substr($0, 1, len-3) "..."; else print; }' )
+
+          message="$line1\n\n$body"
+
+          message="${message//'%'/'%25'}"
+          message="${message//$'\n'/'%0A'}"
+          message="${message//$'\r'/'%0D'}"
+          echo "::set-output name=message::$message"
+
       - name: Create Pull Request
         id: open-pr
         uses: peter-evans/create-pull-request@v4
         with:
           commit-message: |
-            feat(${{ needs.resolve-context.outputs.network }}): register ${{ needs.resolve-context.outputs.moniker }} validator gentx
-
-            Closes #${{ github.event.issue.number }}
+            ${{ steps.commit-message.outputs.message }}
           committer: ${{ secrets.OKP4_BOT_GIT_COMMITTER_NAME }} <${{ secrets.OKP4_BOT_GIT_COMMITTER_EMAIL }}>
           author: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }} <${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}>
           token: ${{ secrets.OKP4_TOKEN }}


### PR DESCRIPTION
Adds a mechanism to limit the size of the commit message (which depends on the length of the provided `moniker`) to comply with the [commitlint](https://commitlint.js.org/) rules. Not essential, but increase quality.