### PR TITLE
Templatize chains readme

### DIFF
--- a/.github/workflows/update-chains-description.yml
+++ b/.github/workflows/update-chains-description.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-  
+
       - name: Install gomplate
         run: |
           curl -s -L -o /usr/local/bin/gomplate https://github.com/hairyhenderson/gomplate/releases/download/v3.11.3/gomplate_linux-amd64 &&
@@ -55,9 +55,10 @@ jobs:
           usersInfo="${TMPDIR}$(uuidgen).json"
           echo "{" >> "$usersInfo"
           first="true"
-          for row in $(cat "./chains/nemeton/genesis.json" | jq -r '.app_state.genutil.gen_txs[].body.messages[].description.identity | select(. != "") | @base64'); do
+          for row in $(cat "./chains/nemeton/genesis.json" \
+            | jq -r '.app_state.genutil.gen_txs[].body.messages[].description.identity | select(. != "") | @base64'); do
               userId=$(echo "$row" | base64 --decode)
-              
+
               echo "🪪 retrieve identity for $userId"
 
               if [ "$first" = "true" ]; then
@@ -66,7 +67,8 @@ jobs:
                   echo "," >> "$usersInfo"
               fi
               echo "\"$userId\": " >> "$usersInfo"
-              curl --silent "https://keybase.io/_/api/1.0/user/user_search.json?q=${userId}&num_wanted=1" | jq ".list[0]" >> "$usersInfo"
+              curl --silent "https://keybase.io/_/api/1.0/user/user_search.json?q=${userId}&num_wanted=1" \
+                | jq ".list[0]" >> "$usersInfo"
           done
           echo "}" >> "$usersInfo"
 

--- a/.github/workflows/update-chains-description.yml
+++ b/.github/workflows/update-chains-description.yml
@@ -1,0 +1,82 @@
+name: Update chains description
+
+on:
+  push:
+    branches: [main]
+
+  workflow_dispatch:
+
+concurrency:
+  group: update-chains-description-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  get-genesis:
+    runs-on: ubuntu-22.04
+    outputs:
+      matrix: ${{ steps.get-genesis.outputs.matrix }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Find genesis files
+        id: get-genesis
+        run: |
+          files=""
+          for file in $(find . -name "genesis.json"); do
+              files="${files:+${files}, }\"${file}\""
+          done
+          echo "matrix={\"context\":[$files]}" >> "$GITHUB_OUTPUT"
+
+  generate-description:
+    name: Run Matrix Job
+    runs-on: ubuntu-22.04
+    needs: [get-genesis]
+    strategy:
+      matrix: ${{ fromJSON(needs.get-genesis.outputs.matrix) }}
+      max-parallel: 2
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+  
+      - name: Install gomplate
+        run: |
+          curl -s -L -o /usr/local/bin/gomplate https://github.com/hairyhenderson/gomplate/releases/download/v3.11.3/gomplate_linux-amd64 &&
+          chmod +x /usr/local/bin/gomplate
+
+      - name: Generate template
+        run: |
+          genesis="${{ matrix.context }}"
+          path=$(dirname "$genesis")
+
+          usersInfo="${TMPDIR}$(uuidgen).json"
+          echo "{" >> "$usersInfo"
+          first="true"
+          for row in $(cat "./chains/nemeton/genesis.json" | jq -r '.app_state.genutil.gen_txs[].body.messages[].description.identity | select(. != "") | @base64'); do
+              userId=$(echo "$row" | base64 --decode)
+              
+              echo "🪪 retrieve identity for $userId"
+
+              if [ "$first" = "true" ]; then
+                  first="false"
+              else
+                  echo "," >> "$usersInfo"
+              fi
+              echo "\"$userId\": " >> "$usersInfo"
+              curl --silent "https://keybase.io/_/api/1.0/user/user_search.json?q=${userId}&num_wanted=1" | jq ".list[0]" >> "$usersInfo"
+          done
+          echo "}" >> "$usersInfo"
+
+          echo "🖨 generate readme from $genesis"
+          gomplate -d genesis="$genesis" -d usersInfo="$usersInfo" -f "$path/README.md.tmpl" -o "$path/README.md"
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_user_name: ${{ secrets.OKP4_BOT_GIT_COMMITTER_NAME }}
+          commit_user_email: ${{ secrets.OKP4_BOT_GIT_COMMITTER_EMAIL }}
+          commit_author: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }} <${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}>
+          commit_message: "docs: update documentation"

--- a/chains/devnet-1/README.md.gtpl
+++ b/chains/devnet-1/README.md.gtpl
@@ -1,3 +1,4 @@
+<!-- generated file - do not edit -->
 # 🔗 `devnet-1`
 
 The main development network, intended primarily for use by the OKP4 core team. This `devnet` functions as a "playground" for those looking to experiment with the protocol as a blockchain user, token holder, application developer or network validator.

--- a/chains/nemeton/README.md.gtpl
+++ b/chains/nemeton/README.md.gtpl
@@ -1,4 +1,9 @@
-# 🔗 `nemeton`
+<!-- generated file - do not edit -->
+# 🔗 `{{ (datasource "genesis").chain_id }}`
+
+![chain-id](https://img.shields.io/badge/chain%20id-{{ (datasource "genesis").chain_id | urlquery | strings.ReplaceAll "-" "--" }}-blue?style=for-the-badge)
+![genesis-time](https://img.shields.io/badge/{{ "⏰" | urlquery }}%20genesis%20time-{{ (datasource "genesis").genesis_time | urlquery | strings.ReplaceAll "-" "--" }}-red?style=for-the-badge)
+![nb-validators](https://img.shields.io/badge/{{ "🧑‍⚖️" | urlquery }}%20core%20validators-{{ (datasource "genesis") | jsonpath "$..messages[?(@.min_self_delegation)]" | len }}-brightgreen?style=for-the-badge)
 
 ## Register in the Genesis
 
@@ -35,3 +40,30 @@ okp4d --home mynode gentx your-key-name 1000000uknow \
   --identity "6C36E7C076BFDCE4" \
   --security-contact "validator@foo.network"
 ```
+
+## Genesis validators
+
+<table>
+  <tr>
+    <th>Moniker</th>
+    <th>Details</th>
+    <th>Identity</th>
+    <th>Site</th>
+  </tr>
+{{- $txs := (datasource "genesis") | jsonpath "$..messages[?(@.min_self_delegation)]" -}}
+{{- range $key, $value := $txs -}}
+{{- $url := "" -}}
+{{- if $value.description.website | strings.HasPrefix "http" -}}
+{{- $url = $value.description.website -}}
+{{- else if $value.description.website -}}
+{{- $url = printf "%s%s" "https://" $value.description.website -}}
+{{- end -}}
+{{- $userInfo := $value.description.identity | index (datasource "usersInfo") }} 
+  <tr>
+   <td><pre>{{ $value.description.moniker | html }}</pre></td>
+   <td>{{ $value.description.details | html }}</td>
+   <td>{{ if $value.description.identity }}<img src="{{ $userInfo.keybase.picture_url }}"/><a href="https://keybase.io/{{ $userInfo.keybase.username }}">{{ $value.description.identity }}</a>{{ end }}</td>
+   <td>{{ if $url }}<a href="{{ $url }}">{{ $url }}</a>{{ end }}
+  </tr>
+{{- end -}}
+</table>


### PR DESCRIPTION
This PR adds a simple README template generation mechanism automated in the CI, based on the `genesis` files, with resolution of identity information fetched from [keybase](keybase.io/).

This allows to easily produce a README, readable and understandable, like the genesis. For instance:

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/9574336/197571103-b3c5bd36-3515-417b-8f7d-0ee1ea1c7602.png">

Note:
- uses [gomplate](https://docs.gomplate.ca/), a template renderer based on go templates.
- partially tested, but probably needs a little tweaking to get it right.