### PR TITLE
Fix/nemeton 1

### DIFF
--- a/.github/ISSUE_TEMPLATE/register-validator.yml
+++ b/.github/ISSUE_TEMPLATE/register-validator.yml
@@ -15,7 +15,7 @@ body:
       description: Choose the OKP4 network you want to join
       multiple: false
       options:
-        - nemeton
+        - nemeton-1
     validations:
       required: true
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -14,11 +14,17 @@ For a complete description about nodes and validators, check out the [OKP4 Docum
 
 ## 🔗 Networks
 
-### [`nemeton`](./chains/nemeton/README.md)
+### [`nemeton-1`](./chains/nemeton/README.md)
 
 ![stability-stable](https://img.shields.io/badge/stability-stable-green.svg) ![audience](https://img.shields.io/badge/audience-public-white.svg)
 
-`Nemeton` is the main OKP4 testnet. Please find more details to join the network [here](chains/nemeton/).
+`Nemeton` is the main OKP4 testnet. Please find more details to join the network [here](chains/nemeton-1/).
+
+### [`nemeton`](./chains/nemeton/README.md)
+
+![stability-deprecated](https://img.shields.io/badge/stability-deprecated-red.svg) ![audience](https://img.shields.io/badge/audience-public-white.svg)
+
+This was the first OKP4 testnet but it is now deprecated, we thus invite all the validators to shutdown their nodes. Youcan still find more details on the network [here](chains/nemeton/).
 
 ### [`devnet-1`](./chains/devnet-1/README.md)
 

--- a/chains/nemeton-1/README.md.gtpl
+++ b/chains/nemeton-1/README.md.gtpl
@@ -5,7 +5,6 @@
 ![stability-stable](https://img.shields.io/badge/stability-stable-green.svg?style=for-the-badge)
 ![audience](https://img.shields.io/badge/audience-public-white.svg?style=for-the-badge)
 ![genesis-time](https://img.shields.io/badge/{{ "⏰" | urlquery }}%20genesis%20time-{{ (datasource "genesis").genesis_time | urlquery | strings.ReplaceAll "-" "--" }}-red?style=for-the-badge)
-![nb-validators](https://img.shields.io/badge/{{ "🧑‍⚖️" | urlquery }}%20core%20validators-{{ (datasource "genesis") | jsonpath "$..messages[?(@.min_self_delegation)]" | len }}-brightgreen?style=for-the-badge)
 
 ## Register in the Genesis
 
@@ -43,33 +42,3 @@ okp4d --home mynode gentx your-key-name 10000000000uknow \
   --security-contact "validator@foo.network"
 ```
 
-## Genesis validators
-
-Here's the list of the current 
-
-<table>
-  <tr>
-    <th>Moniker</th>
-    <th>Details</th>
-    <th>Identity</th>
-    <th>Site</th>
-  </tr>
-{{- $txs := (datasource "genesis") | jsonpath "$..messages[?(@.min_self_delegation)]" -}}
-{{- range $key, $value := $txs }}
-{{- $url := "" -}}
-{{- if $value.description.website | strings.HasPrefix "http" -}}
-{{- $url = $value.description.website -}}
-{{- else if $value.description.website -}}
-{{- $url = printf "%s%s" "https://" $value.description.website -}}
-{{- end -}}
-{{- $userInfo := $value.description.identity | index (datasource "usersInfo") }}
-  <tr>
-   <td><pre>{{ $value.description.moniker | html }}</pre></td>
-   <td>{{ $value.description.details | html }}</td>
-   <td>{{ if $value.description.identity }}
-     <p align="center"><img width="80px" src="{{ $userInfo.keybase.picture_url }}"/></p>
-     <a href="https://keybase.io/{{ $userInfo.keybase.username }}">{{ $value.description.identity }}</a>{{ end }}</td>
-   <td>{{ if $url }}<a href="{{ $url }}">{{ $url }}</a>{{ end -}}
-  </tr>
-{{- end }}
-</table>


### PR DESCRIPTION
- Allow only registering gentx on the `okp4-nemeton-1` genesis.
- Reference `okp4-nemeton-1` as the official OKP4 testnet in readme.
- Deprecate `okp4-nemeton` in readme.