### PR TITLE
ci: Automatically resolve registering conflicts

### DIFF
--- a/.github/workflows/resolve-register-conflict.yml
+++ b/.github/workflows/resolve-register-conflict.yml
@@ -43,6 +43,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.OKP4_TOKEN }}
 
+      - name: Get network register config
+        id: register-config
+        run: |
+          set -eo pipefail
+          config=$(cat chains/${{ steps.next-pr.outputs.chain-id }}/register-config.json | jq -c '.')
+          echo "config=${config}" >> $GITHUB_OUTPUT
+
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v5
         with:
@@ -57,49 +64,43 @@ jobs:
         run: |
           set -eo pipefail
           CHAIN_ID=${{ steps.next-pr.outputs.chain-id }}
+          BRANCH=${{ steps.next-pr.outputs.headRefName }}
+          ISSUE_NUM=$(echo "$BRANCH" | sed 's/feat\///' | cut -c1-3)
 
-          git switch ${{ steps.next-pr.outputs.headRefName }}
+          git switch $BRANCH
 
-          if [ -z "$(git diff --check  main)" ]; then
+          MERGE_BASE=$(git merge-base $BRANCH main)
+          git merge-tree $MERGE_BASE $BRANCH main | xargs |
+          if grep -oe '<<<<<<<.*=======.*>>>>>>>';then
+              echo "conflict-exists=true" >> $GITHUB_OUTPUT
+          else
             echo No merge conflicts
             echo "conflict-exists=false" >> $GITHUB_OUTPUT
             exit 0
-          else
-            echo "conflict-exists=true" >> $GITHUB_OUTPUT
           fi
-
-          git diff @~ @ -- chains/$CHAIN_ID/genesis.json > temp-diff.patch
-          PATCH=$(grep ^\+ temp-diff.patch | cut -c2-)
-          ACCOUNT_ELT=$(echo $PATCH | grep -o -E '(\{ "@type": "/cosmos.auth.v1beta1.BaseAccount"[^}]*})')
-          BALANCE_ELT=$(echo $PATCH | grep -o -E '(\{ "address": [^}]*} ] })')
-          GENTX_ELT=$(echo $PATCH | grep -o -E '(\{ "body".*)')
-          if [[ $GENTX_ELT != *} ]]; then
-            GENTX_ELT=$(echo $GENTX_ELT"}")
-          fi
-          if [ "$(echo $ACCOUNT_ELT | jq .address)" = 'null' ]; then
-            echo wrong account elt >&2
-            exit 1
-          fi
-          if [ "$(echo $BALANCE_ELT | jq .address)" = 'null' ]; then
-            echo wrong balance elt >&2
-            exit 1
-          fi
-          if [ "$(echo $GENTX_ELT | jq .body.messages[0].description.moniker)" = 'null' ]; then
-            echo wrong gentx elt >&2
-            exit 1
-          fi
-
-          git show main:chains/$CHAIN_ID/genesis.json \
-          | jq ".app_state.auth.accounts += [$ACCOUNT_ELT]" \
-          | jq ".app_state.bank.balances += [$BALANCE_ELT]" \
-          | jq ".app_state.genutil.gen_txs += [$GENTX_ELT]" \
-            > genesis-temp.json
 
           git config user.name "$GIT_USER_NAME"
           git config user.email "$GIT_USER_MAIL"
+
           git rebase -X ours main
-          mv genesis-temp.json chains/$CHAIN_ID/genesis.json
+
+          git show main:chains/$CHAIN_ID/genesis.json > ./chains/$CHAIN_ID/genesis.json
+
+          GENTX=$(cat chains/$CHAIN_ID/gentx/gentx-$ISSUE_NUM.json)
+          OKP4D_VERSION=$(cat ./chains/$CHAIN_ID/version.txt)
+
+          mkdir -p $NODE_HOME
+          docker run --rm -v $NODE_HOME:$NODE_HOME okp4/okp4d:$OKP4D_VERSION init --home $NODE_HOME whatever
+          sudo cp chains/$CHAIN_ID/genesis.json $NODE_HOME/config/genesis.json
+
+          delegator_addr=$(echo "$GENTX" | jq -r '.body.messages[0].delegator_address')
+          delegator_balance="`expr ${{ fromJson(steps.register-config.outputs.config).delegation.amount }} + 200000`${{ fromJson(steps.register-config.outputs.config).delegation.denom }}"
+          docker run --rm -v $NODE_HOME:$NODE_HOME okp4/okp4d:$OKP4D_VERSION add-genesis-account --home $NODE_HOME $delegator_addr $delegator_balance
+
+          docker run --rm -v $NODE_HOME:$NODE_HOME -v $PWD/chains/$CHAIN_ID/gentx:/gentx okp4/okp4d:$OKP4D_VERSION collect-gentxs --home $NODE_HOME --gentx-dir /gentx
+          cp $NODE_HOME/config/genesis.json chains/$CHAIN_ID/genesis.json
         env:
+          NODE_HOME: /tmp/node
           BRANCH: ${{ steps.next-pr.outputs.headRefName }}
           GIT_USER_NAME: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }}
           GIT_USER_MAIL: ${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}

--- a/.github/workflows/resolve-register-conflict.yml
+++ b/.github/workflows/resolve-register-conflict.yml
@@ -1,0 +1,97 @@
+name: Auto resolve register validator conflicts
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: resolve-conflict
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    runs-on: ubuntu-22.04
+    outputs:
+      pr-matrix: ${{ steps.pr-matrix.outputs.pr-list }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: prepare branch list
+        id: pr-matrix
+        run: |
+          PR_LIST=$(gh pr list --json title,headRefName,mergeStateStatus --search "org:okp4 repo:okp4/networks state:open ⚖ Register in:title author:bot-anik")
+          echo "pr-list=${PR_LIST}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.OKP4_TOKEN }}
+
+  resolve-conflicts:
+    if: needs.prepare.outputs.pr-matrix != '[]'
+    runs-on: ubuntu-22.04
+    needs: prepare
+    strategy:
+      matrix:
+        context: ${{ fromJson(needs.prepare.outputs.pr-matrix) }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: rebase and resolve genesis conflicts
+        if: ${{ matrix.context.mergeStateStatus }} == 'DIRTY'
+        run: |
+          set -eo pipefail
+          CHAIN_ID=${BRANCH##*register-}
+
+          git switch ${{ matrix.context.headRefName }}
+
+          git diff @~ @ -- chains/$CHAIN_ID/genesis.json > temp-diff.patch
+
+          PATCH=$(grep ^\+ temp-diff.patch | cut -c2-)
+
+          ACCOUNT_ELT=$(echo $PATCH | grep -o -P '(?<="accounts": \[ ).*(?= \] "balances)')
+          BALANCE_ELT=$(echo $PATCH | grep -o -P '(?<="balances": \[ ).*(?= \], "gen_txs)')
+          GENTX_ELT=$(echo $PATCH | grep -o -P '(?<="gen_txs": \[ ).*(?= \] })')
+
+          if [ "$(echo $ACCOUNT_ELT | jq .address)" = 'null' ]; then
+            exit 1
+          fi
+
+          if [ "$(echo $BALANCE_ELT | jq .address)" = 'null' ]; then
+            exit 1
+          fi
+
+          if [ "$(echo $GENTX_ELT | jq .body.messages[0].description.moniker)" = 'null' ]; then
+            exit 1
+          fi
+
+          git show main:chains/$CHAIN_ID/genesis.json \
+          | jq ".app_state.auth.accounts += [$ACCOUNT_ELT]" \
+          | jq ".app_state.bank.balances += [$BALANCE_ELT]" \
+          | jq ".app_state.genutil.gen_txs += [$GENTX_ELT]" \
+            > genesis-temp.json
+
+          git config user.name "$GIT_USER_NAME"
+          git config user.email "$GIT_USER_MAIL"
+          git rebase -X ours main
+          mv genesis-temp.json chains/$CHAIN_ID/genesis.json
+        env:
+          BRANCH: ${{ matrix.context.headRefName }}
+          GIT_USER_NAME: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }}
+          GIT_USER_MAIL: ${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}
+
+      - name: Get last commit message
+        id: last-commit-message
+        run: |
+          echo "msg=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
+
+      - name: amend commit and force push
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: ${{ steps.last-commit-message.outputs.msg }}
+          commit_options: "--amend --no-edit"
+          push_options: "--force"
+          file_pattern: "chains/*/genesis.json"
+          skip_fetch: true

--- a/.github/workflows/resolve-register-conflict.yml
+++ b/.github/workflows/resolve-register-conflict.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           set -eo pipefail
           LABEL_PREFIX="chain: ⛓️"
-          PR_LIST=$(gh pr list --json headRefName,mergeStateStatus,labels --search "org:okp4 repo:okp4/networks state:open label:register-validator author:bot-anik sort:created-asc")
+          PR_LIST=$(gh pr list --json headRefName,labels --search "org:okp4 repo:okp4/networks state:open label:register-validator author:bot-anik sort:created-asc")
           NUM_OF_PR=$(echo $PR_LIST | jq '. | length')
           if [[ $NUM_OF_PR = 0 ]]; then
             echo No PR waiting
@@ -34,14 +34,10 @@ jobs:
           CHAIN_LABEL=$(echo $OLDEST_PR | jq .labels | jq -r ".[] | select(.name | startswith(\"${LABEL_PREFIX}\"))" | jq .name)
           CHAIN_ID=$(echo ${CHAIN_LABEL/${LABEL_PREFIX}/} | tr -d ' ')
           if [ -z "$CHAIN_ID" ]; then
-            echo "No chain id on label" >&2
+            echo "No chain id on label"
             exit
           fi
-          echo "mergeStateStatus=$(echo $OLDEST_PR | jq .mergeStateStatus )"
-          echo "chain-id=${CHAIN_ID}"
-          echo "headRefName=$(echo $OLDEST_PR | jq .headRefName )"
 
-          echo "mergeStateStatus=$(echo $OLDEST_PR | jq .mergeStateStatus )" >> $GITHUB_OUTPUT
           echo "chain-id=${CHAIN_ID}" >> $GITHUB_OUTPUT
           echo "headRefName=$(echo $OLDEST_PR | jq .headRefName )" >> $GITHUB_OUTPUT
         env:
@@ -57,12 +53,20 @@ jobs:
           git_commit_gpgsign: true
 
       - name: rebase and resolve genesis conflicts
-        if: contains( steps.next-pr.outputs.mergeStateStatus, 'DIRTY')
+        id: resolve-conflict
         run: |
           set -eo pipefail
           CHAIN_ID=${{ steps.next-pr.outputs.chain-id }}
 
           git switch ${{ steps.next-pr.outputs.headRefName }}
+
+          if [ -z "$(git diff --check  main)" ]; then
+            echo No merge conflicts
+            echo "conflict-exists=false" >> $GITHUB_OUTPUT
+            exit 0
+          else
+            echo "conflict-exists=true" >> $GITHUB_OUTPUT
+          fi
 
           git diff @~ @ -- chains/$CHAIN_ID/genesis.json > temp-diff.patch
           PATCH=$(grep ^\+ temp-diff.patch | cut -c2-)
@@ -101,13 +105,13 @@ jobs:
           GIT_USER_MAIL: ${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}
 
       - name: Get last commit message
-        if: contains( steps.next-pr.outputs.mergeStateStatus, 'DIRTY')
+        if: steps.resolve-conflict.outputs.conflict-exists == 'true'
         id: last-commit-message
         run: |
           echo "msg=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
 
       - name: amend commit and force push
-        if: contains( steps.next-pr.outputs.mergeStateStatus, 'DIRTY')
+        if: steps.resolve-conflict.outputs.conflict-exists == 'true'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: ${{ steps.last-commit-message.outputs.msg }}

--- a/.github/workflows/resolve-register-conflict.yml
+++ b/.github/workflows/resolve-register-conflict.yml
@@ -39,6 +39,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.OKP4_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.OKP4_BOT_GPG_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
       - name: rebase and resolve genesis conflicts
         if: ${{ matrix.context.mergeStateStatus }} == 'DIRTY'
         run: |

--- a/.github/workflows/resolve-register-conflict.yml
+++ b/.github/workflows/resolve-register-conflict.yml
@@ -4,40 +4,48 @@ on:
   push:
     branches: [main]
 
+  workflow_dispatch:
+
 concurrency:
   group: resolve-conflict
   cancel-in-progress: true
 
 jobs:
-  prepare:
+  resolve-next-pr-conflicts:
     runs-on: ubuntu-22.04
-    outputs:
-      pr-matrix: ${{ steps.pr-matrix.outputs.pr-list }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-
-      - name: prepare branch list
-        id: pr-matrix
-        run: |
-          PR_LIST=$(gh pr list --json title,headRefName,mergeStateStatus --search "org:okp4 repo:okp4/networks state:open ⚖ Register in:title author:bot-anik")
-          echo "pr-list=${PR_LIST}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TOKEN: ${{ secrets.OKP4_TOKEN }}
-
-  resolve-conflicts:
-    if: needs.prepare.outputs.pr-matrix != '[]'
-    runs-on: ubuntu-22.04
-    needs: prepare
-    strategy:
-      matrix:
-        context: ${{ fromJson(needs.prepare.outputs.pr-matrix) }}
-
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: prepare branch list
+        id: next-pr
+        run: |
+          set -eo pipefail
+          LABEL_PREFIX="chain: ⛓️"
+          PR_LIST=$(gh pr list --json headRefName,mergeStateStatus,labels --search "org:okp4 repo:okp4/networks state:open label:register-validator author:bot-anik sort:created-asc")
+          NUM_OF_PR=$(echo $PR_LIST | jq '. | length')
+          if [[ $NUM_OF_PR = 0 ]]; then
+            echo No PR waiting
+            exit
+          fi
+          OLDEST_PR=$(echo $PR_LIST | jq '.[0]')
+          CHAIN_LABEL=$(echo $OLDEST_PR | jq .labels | jq -r ".[] | select(.name | startswith(\"${LABEL_PREFIX}\"))" | jq .name)
+          CHAIN_ID=$(echo ${CHAIN_LABEL/${LABEL_PREFIX}/} | tr -d ' ')
+          if [ -z "$CHAIN_ID" ]; then
+            echo "No chain id on label" >&2
+            exit
+          fi
+          echo "mergeStateStatus=$(echo $OLDEST_PR | jq .mergeStateStatus )"
+          echo "chain-id=${CHAIN_ID}"
+          echo "headRefName=$(echo $OLDEST_PR | jq .headRefName )"
+
+          echo "mergeStateStatus=$(echo $OLDEST_PR | jq .mergeStateStatus )" >> $GITHUB_OUTPUT
+          echo "chain-id=${CHAIN_ID}" >> $GITHUB_OUTPUT
+          echo "headRefName=$(echo $OLDEST_PR | jq .headRefName )" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.OKP4_TOKEN }}
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v5
@@ -49,30 +57,31 @@ jobs:
           git_commit_gpgsign: true
 
       - name: rebase and resolve genesis conflicts
-        if: ${{ matrix.context.mergeStateStatus }} == 'DIRTY'
+        if: contains( steps.next-pr.outputs.mergeStateStatus, 'DIRTY')
         run: |
           set -eo pipefail
-          CHAIN_ID=${BRANCH##*register-}
+          CHAIN_ID=${{ steps.next-pr.outputs.chain-id }}
 
-          git switch ${{ matrix.context.headRefName }}
+          git switch ${{ steps.next-pr.outputs.headRefName }}
 
           git diff @~ @ -- chains/$CHAIN_ID/genesis.json > temp-diff.patch
-
           PATCH=$(grep ^\+ temp-diff.patch | cut -c2-)
-
-          ACCOUNT_ELT=$(echo $PATCH | grep -o -P '(?<="accounts": \[ ).*(?= \] "balances)')
-          BALANCE_ELT=$(echo $PATCH | grep -o -P '(?<="balances": \[ ).*(?= \], "gen_txs)')
-          GENTX_ELT=$(echo $PATCH | grep -o -P '(?<="gen_txs": \[ ).*(?= \] })')
-
+          ACCOUNT_ELT=$(echo $PATCH | grep -o -E '(\{ "@type": "/cosmos.auth.v1beta1.BaseAccount"[^}]*})')
+          BALANCE_ELT=$(echo $PATCH | grep -o -E '(\{ "address": [^}]*} ] })')
+          GENTX_ELT=$(echo $PATCH | grep -o -E '(\{ "body".*)')
+          if [[ $GENTX_ELT != *} ]]; then
+            GENTX_ELT=$(echo $GENTX_ELT"}")
+          fi
           if [ "$(echo $ACCOUNT_ELT | jq .address)" = 'null' ]; then
+            echo wrong account elt >&2
             exit 1
           fi
-
           if [ "$(echo $BALANCE_ELT | jq .address)" = 'null' ]; then
+            echo wrong balance elt >&2
             exit 1
           fi
-
           if [ "$(echo $GENTX_ELT | jq .body.messages[0].description.moniker)" = 'null' ]; then
+            echo wrong gentx elt >&2
             exit 1
           fi
 
@@ -87,16 +96,18 @@ jobs:
           git rebase -X ours main
           mv genesis-temp.json chains/$CHAIN_ID/genesis.json
         env:
-          BRANCH: ${{ matrix.context.headRefName }}
+          BRANCH: ${{ steps.next-pr.outputs.headRefName }}
           GIT_USER_NAME: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }}
           GIT_USER_MAIL: ${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}
 
       - name: Get last commit message
+        if: contains( steps.next-pr.outputs.mergeStateStatus, 'DIRTY')
         id: last-commit-message
         run: |
           echo "msg=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
 
       - name: amend commit and force push
+        if: contains( steps.next-pr.outputs.mergeStateStatus, 'DIRTY')
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: ${{ steps.last-commit-message.outputs.msg }}


### PR DESCRIPTION
When there's a push on main. For every registering PR in `DIRTY` state, 
- [x] rebase main
- [x] try to extract diff from last commit and inject the added element in genesis.json at the right place.
- [x] bot-anik signed commit

then amend last commit and force push ⚠️ hoping nothing goes wrong here 🫣 maybe a regular commit and a squash merge would be better?