### PR TITLE
ci(workflow): add label for the considered chain to the PR

### DIFF
--- a/.github/workflows/register-validator.yml
+++ b/.github/workflows/register-validator.yml
@@ -167,7 +167,7 @@ jobs:
           title: '⚖️ Register `${{ needs.resolve-context.outputs.moniker }}` Validator'
           body: |
             Register [new validator](${{ github.event.issue.html_url }}) gentx on the ${{ needs.resolve-context.outputs.network }} network.
-          labels: register-validator
+          labels: "register-validator,chain: ⛓️ ${{ needs.resolve-context.outputs.network }}"
           assignees: amimart,ccamel
           reviewers: amimart,ccamel,tpelliet
 


### PR DESCRIPTION
Self explanatory. Adds the label for the considered chain to the PR created for registering a validator. Not extraordinary, but allows to better classify the PR of this type.

*Note-1*: this implies that the label must exist, i.e. for any new chain created the associated label must be created in the repository.
*Note-2*:  I already applied the labels for the `nemeton` and `nemeton-1` chains by hand.